### PR TITLE
Fixes a Swift build issue and adds "SHOW" and "HIDE" states to the PasswordSupplementaryView

### DIFF
--- a/Pod/Classes/Logic/Helpers/ErrorsProvider/YALBaseErrorsProvider+YALPrivate.h
+++ b/Pod/Classes/Logic/Helpers/ErrorsProvider/YALBaseErrorsProvider+YALPrivate.h
@@ -1,6 +1,6 @@
 // For License please refer to LICENSE file in the root of YALField project
 
-#import "YALErrorsProvider.h"
+#import "YALBaseErrorsProvider.h"
 
 @interface YALBaseErrorsProvider (YALPrivate)
 

--- a/Pod/Classes/Views/SupplementaryViews/Password/YALPasswordSupplementaryView.m
+++ b/Pod/Classes/Views/SupplementaryViews/Password/YALPasswordSupplementaryView.m
@@ -58,10 +58,14 @@ static NSString *const kDefaultPasswordViewFontName = @"HelveticaNeue";
 #pragma mark - Action
 
 - (IBAction)showSecuredTextButtonTouchUpInside {
-    if (self.field.secured) {
-        self.field.secured = NO;
-        [YALBaseDataFlowController inputDidReceiveTouchEvent:self.field];
+    self.field.textField.secureTextEntry = !self.field.textField.secureTextEntry;
+    if (self.field.textField.secureTextEntry) {
+        [self.showPasswordButton setTitle:@"SHOW" forState:UIControlStateNormal];
     }
+    else {
+        [self.showPasswordButton setTitle:@"HIDE" forState:UIControlStateNormal];
+    }
+    [YALBaseDataFlowController inputDidReceiveTouchEvent:self.field];
 }
 
 @end


### PR DESCRIPTION
This pull request fixes one build issue when building the library for Swift applications (issue #3) and adds support for "SHOW" and "HIDE" states to the PasswordSupplementaryView. These new states allow the user to view the password as plain text easily, but can just as easily secure the text again.